### PR TITLE
Fixes two possible typos in the documentation

### DIFF
--- a/docs/rules/only-spread-css.md
+++ b/docs/rules/only-spread-css.md
@@ -38,7 +38,7 @@ import { css } from 'withStyles';
 
 ```jsx
 import { css } from 'withStyles';
-<div {...css(styles.foo) { color: 'red' }} />
+<div {...css(styles.foo, { color: 'red' })} />
 ```
 
 ## Known limitations
@@ -47,7 +47,7 @@ import { css } from 'withStyles';
 
   ```jsx
   const bar = { className: 'foo' };
-  <div {...css(styles.foo} {...bar} />
+  <div {...css(styles.foo)} {...bar} />
   ```
 
 - Does not keep track of assigning the `css()` function to a different variable.


### PR DESCRIPTION
I think there are two typos in the documentation's examples, that I've corrected here. 