### PR TITLE
Update for eslint v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
   },
   "homepage": "https://github.com/airbnb/eslint-plugin-react-with-styles#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "eslint": "^3.13.1",
-    "eslint-config-airbnb-base": "^11.0.1",
-    "eslint-plugin-import": "^2.2.0",
+    "chai": "^4.1.0",
+    "eslint": "^4.3.0",
+    "eslint-config-airbnb-base": "^11.3.0",
+    "eslint-plugin-import": "^2.7.0",
     "in-publish": "^2.0.0",
     "mocha": "^3.2.0",
     "safe-publish-latest": "^1.1.1"

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,8 +14,7 @@ describe('all rule files are exported by the plugin', () => {
     it(`exports ${ruleName}`, () => {
       expect(plugin.rules[ruleName])
         // eslint-disable-next-line global-require, import/no-dynamic-require
-        .to.eql(require(path.join('../lib/rules', ruleName))
-      );
+        .to.eql(require(path.join('../lib/rules', ruleName)));
     });
   });
 });


### PR DESCRIPTION
From what I can tell, none of the breaking changes affect this plugin.

http://eslint.org/docs/user-guide/migrating-to-4.0.0

While I was at it, I bumped some devDependencies and fixed a new linting
error that appeared with the update.

Fixes #21 