### PR TITLE
Add cssNoRTL-only rule to enforce use of cssNoRTL on particular components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# lockfiles
+yarn.lock
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/docs/rules/cssNoRTL-only.md
+++ b/docs/rules/cssNoRTL-only.md
@@ -1,0 +1,45 @@
+# Force certain components to use cssNoRTL. (cssNoRTL-only)
+
+`cssNoRTL-only` is a configurable rule that allows applications to force certain components to use `cssNoRTL` over the default `css` call for styling.
+
+Why would you want to do this?
+
+Specifically, if your application relies on `react-with-styles-interface-aphrodite/with-rtl` as its primary interface, the default behavior of the `css` (née `resolve`) method may not always be desired. Specifically, if you pass in a vanilla object into the method (as opposed to a reference to the `styles` prop), it may be converted to a class instead of remaining an inline style in order to support flipping the style in a right-to-left (RTL) environment. While this is fine much of the time, there are scenarios where you might not want this to happen, specifically if you are using a library that relies on an explicit inline style (you are using `react-virtualized` for instance) or converting from an inline style would be less performant (when relying on `react-motion` or `animated-js`). For these components, you may wish to enforce a rule where they use `cssNoRTL` in place of `css` for their styling.
+
+## Rule Details
+
+This rule allows you to specify components that must use `cssNoRTL` over `css` for styling.
+
+## Options
+The syntax to specify components looks like this:
+
+```json
+"cssNoRTL-only": ["error", "Component1", "Component2"]
+```
+
+## Examples
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint "cssNoRTL-only": ["error", "Animated"]*/
+import { css } from 'react-with-styles';
+
+function MyComponent({ styles }) {
+  return (
+    <Animated {...css(styles.foo)}>foo</Animated>
+  );
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint "cssNoRTL-only": ["error", "Animated"]*/
+import { cssNoRTL } from 'react-with-styles';
+
+function MyComponent({ styles }) {
+  return (
+    <Animated {...cssNoRTL(styles.foo)}>foo</Animated>
+  );
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const cssNoRTLOnly = require('./rules/cssNoRTL-only.js');
 const onlySpreadCSS = require('./rules/only-spread-css');
 const noUnusedStyles = require('./rules/no-unused-styles');
 
 module.exports = {
   rules: {
+    'cssNoRTL-only': cssNoRTLOnly,
     'only-spread-css': onlySpreadCSS,
     'no-unused-styles': noUnusedStyles,
   },
@@ -12,7 +14,7 @@ module.exports = {
   configs: {
     recommended: {
       rules: {
-        'react-with-styles/only-spread-css': 2,
+        'react-with-styles/only-spread-css': 'error',
       },
     },
   },

--- a/lib/rules/cssNoRTL-only.js
+++ b/lib/rules/cssNoRTL-only.js
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Force usage of cssNoRTL over css for certain components.
+ * @author Maja Wichrowska
+ */
+
+'use strict';
+
+const findImportCSSFromWithStylesImportDeclaration = require('../util/findImportCSSFromWithStylesImportDeclaration');
+const findRequireCSSFromWithStylesCallExpression = require('../util/findRequireCSSFromWithStylesCallExpression');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Force restricted components to use the RWS cssNoRTL method instead of the regular css method',
+      recommended: false,
+    },
+
+    schema: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      uniqueItems: true,
+    },
+  },
+
+  create(context) {
+    const restrictedComponents = new Set(context.options);
+
+    // if no components are restricted we don't need to check for restricted css calls
+    if (restrictedComponents.length === 0) {
+      return {};
+    }
+
+    // If `css()` is imported by this file, we want to store what it is imported
+    // as in this variable so we can verify where it is used.
+    let cssFromWithStylesName;
+
+    function isCSSFound() {
+      return !!cssFromWithStylesName;
+    }
+
+    function getObjectSpreadFunctionName(node) {
+      const callee = node.argument.callee;
+      if (!callee) return null;
+      return callee.name;
+    }
+
+    function getComponentNameFromAttribute(node) {
+      return node.parent.name.name;
+    }
+
+    return {
+      CallExpression(node) {
+        if (isCSSFound()) {
+          // We've already found it, so there is no more work to do.
+          return;
+        }
+
+        const found = findRequireCSSFromWithStylesCallExpression(node);
+        if (found !== null) {
+          cssFromWithStylesName = found;
+        }
+      },
+
+      ImportDeclaration(node) {
+        if (isCSSFound()) {
+          // We've already found it, so there is no more work to do.
+          return;
+        }
+
+        const found = findImportCSSFromWithStylesImportDeclaration(node);
+        if (found !== null) {
+          cssFromWithStylesName = found;
+        }
+      },
+
+      JSXSpreadAttribute(node) {
+        const functionName = getObjectSpreadFunctionName(node);
+        const componentName = getComponentNameFromAttribute(node);
+
+        if (!functionName || !componentName) return null;
+
+        if (functionName === 'css') {
+          if (restrictedComponents.has(componentName)) {
+            context.report(node, "'<{{componentName}} />' must use the 'cssNoRTL' method in place of the 'css' method.", {
+              componentName,
+            });
+          }
+        }
+
+        return null;
+      },
+    };
+  },
+};

--- a/tests/lib/rules/cssNoRTL-only.js
+++ b/tests/lib/rules/cssNoRTL-only.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Tests for cssNoRTL-only.
+ * @author Maja Wichrowska
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/cssNoRTL-only');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('cssNoRTL-only', rule, {
+  valid: [
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <div {...css()} />
+      `,
+      options: [],
+    },
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <div {...css} />
+      `,
+      options: ['Animated'],
+    },
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <div {...cssNoRTL()} />
+      `,
+      options: [],
+    },
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <div {...css()} />
+      `,
+      options: ['Animated'],
+    },
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <div {...cssNoRTL()} />
+      `,
+      options: ['Animated', 'Motion'],
+    },
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <Animated {...cssNoRTL()} />
+      `,
+      options: ['Animated', 'Motion'],
+    },
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <Motion {...cssNoRTL()} />
+      `,
+      options: ['Animated', 'Motion'],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { css } from 'react-with-styles';
+        <Animated {...css()} />
+      `,
+      options: ['Animated', 'Motion'],
+      errors: [{
+        message: "'<Animated />' must use the 'cssNoRTL' method in place of the 'css' method.",
+        type: 'JSXSpreadAttribute',
+      }],
+    },
+    {
+      code: `
+        const css = require('react-with-styles').css;
+        <Animated {...css()} />
+      `,
+      options: ['Animated', 'Motion'],
+      errors: [{
+        message: "'<Animated />' must use the 'cssNoRTL' method in place of the 'css' method.",
+        type: 'JSXSpreadAttribute',
+      }],
+    },
+  ],
+});


### PR DESCRIPTION
This is a new configurable rule that we want to begin enforcing after https://github.com/airbnb/react-with-styles/pull/95 and https://github.com/airbnb/react-with-styles-interface-aphrodite/pull/15 get merged in and the versions bumped in our internal repos.

The idea is that we would use these rules to enforce using the noRTL of the css call specifically with Animated.js/react-motion (those are libraries that use the style attribute to do animations and thus would be super non-performant if we forced that update to use classnames instead (which is the current solution for RTL). Other components may also require this restriction in the future.

I think I also need to add in regex support for this rule, because ultimately, we need to prevent Animated.* from using css I think.

to: @ljharb @lencioni 