### PR TITLE
Remove requirement that css be imported from the global in no-unused-styles

### DIFF
--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -2,9 +2,6 @@
 
 const has = require('has');
 
-const findImportCSSFromWithStylesImportDeclaration = require('../util/findImportCSSFromWithStylesImportDeclaration');
-const findRequireCSSFromWithStylesCallExpression = require('../util/findRequireCSSFromWithStylesCallExpression');
-
 function getBasicIdentifier(node) {
   if (node.type === 'Identifier') {
     // styles.foo
@@ -37,31 +34,11 @@ module.exports = {
   },
 
   create: function rule(context) {
-    // If `css()` is imported by this file, we want to store what it is imported
-    // as in this variable so we can verify where it is used.
-    let cssFromWithStylesName;
-
     const usedStyles = {};
     const definedStyles = {};
 
-    function isCSSFound() {
-      return !!cssFromWithStylesName;
-    }
-
     return {
       CallExpression(node) {
-        const found = findRequireCSSFromWithStylesCallExpression(node);
-        if (found !== null) {
-          cssFromWithStylesName = found;
-        }
-
-        // foo()
-        if (!isCSSFound()) {
-          // We are not importing `css` from withStyles, so we have no work to
-          // do here.
-          return;
-        }
-
         if (node.callee.name === 'withStyles') {
           const styles = node.arguments[0];
 
@@ -117,12 +94,6 @@ module.exports = {
       },
 
       MemberExpression(node) {
-        if (!isCSSFound()) {
-          // We are not importing `css` from withStyles, so we have no work to
-          // do here.
-          return;
-        }
-
         if (node.object.type === 'Identifier' && node.object.name === 'styles') {
           const style = getBasicIdentifier(node.property);
           if (style) {
@@ -170,18 +141,6 @@ module.exports = {
         const style = getBasicIdentifier(parent.property);
         if (style) {
           usedStyles[style] = true;
-        }
-      },
-
-      ImportDeclaration(node) {
-        if (isCSSFound()) {
-          // We've already found it, so there is no more work to do.
-          return;
-        }
-
-        const found = findImportCSSFromWithStylesImportDeclaration(node);
-        if (found !== null) {
-          cssFromWithStylesName = found;
         }
       },
     };

--- a/lib/rules/only-spread-css.js
+++ b/lib/rules/only-spread-css.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const findImportCSSFromWithStylesImportDeclaration = require('../util/findImportCSSFromWithStylesImportDeclaration');
-const findRequireCSSFromWithStylesCallExpression = require('../util/findRequireCSSFromWithStylesCallExpression');
-
 module.exports = {
   meta: {
     docs: {
@@ -14,29 +11,10 @@ module.exports = {
   },
 
   create: function rule(context) {
-    // If `css()` is imported by this file, we want to store what it is imported
-    // as in this variable so we can verify where it is used.
-    let cssFromWithStylesName;
-
-    function isCSSFound() {
-      return !!cssFromWithStylesName;
-    }
-
+    const CSS_METHOD_NAME = 'css';
     return {
       CallExpression(node) {
-        const found = findRequireCSSFromWithStylesCallExpression(node);
-        if (found !== null) {
-          cssFromWithStylesName = found;
-        }
-
-        // foo()
-        if (!isCSSFound()) {
-          // We are not importing `css` from withStyles, so we have no work to
-          // do here.
-          return;
-        }
-
-        if (node.callee.name !== cssFromWithStylesName) {
+        if (node.callee.name !== CSS_METHOD_NAME) {
           // foo()
           return;
         }
@@ -48,30 +26,11 @@ module.exports = {
 
         context.report(
           node,
-          `Only spread \`${cssFromWithStylesName}()\` directly into an element, e.g. \`<div {...${cssFromWithStylesName}(foo)} />\`.`
+          `Only spread \`${CSS_METHOD_NAME}()\` directly into an element, e.g. \`<div {...${CSS_METHOD_NAME}(foo)} />\`.`
         );
       },
 
-      ImportDeclaration(node) {
-        if (isCSSFound()) {
-          // We've already found it, so there is no more work to do.
-          return;
-        }
-
-        const found = findImportCSSFromWithStylesImportDeclaration(node);
-        if (found !== null) {
-          cssFromWithStylesName = found;
-        }
-      },
-
       JSXSpreadAttribute(node) {
-        // <div {...foo()} />
-        if (!isCSSFound()) {
-          // We are not importing `css` from withStyles, so we have no work to
-          // do here.
-          return;
-        }
-
         if (node.argument.type !== 'CallExpression') {
           // <div {...foo} />
           //
@@ -81,7 +40,7 @@ module.exports = {
           return;
         }
 
-        if (node.argument.callee.name !== cssFromWithStylesName) {
+        if (node.argument.callee.name !== CSS_METHOD_NAME) {
           // <div {...foo()} />
           return;
         }
@@ -109,7 +68,7 @@ module.exports = {
           if (attribute.name.name === 'className') {
             context.report(
               attribute,
-              `Do not use \`className\` with \`{...${cssFromWithStylesName}()}\`.`
+              `Do not use \`className\` with \`{...${CSS_METHOD_NAME}()}\`.`
             );
             return;
           }
@@ -117,7 +76,7 @@ module.exports = {
           if (attribute.name.name === 'style') {
             context.report(
               attribute,
-              `Do not use \`style\` with \`{...${cssFromWithStylesName}()}\`.`
+              `Do not use \`style\` with \`{...${CSS_METHOD_NAME}()}\`.`
             );
           }
         });

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -486,6 +486,21 @@ ruleTester.run('no-unused-styles', rule, {
         }))(Foo);
       `.trim(),
     },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
   ],
 
   invalid: [
@@ -617,6 +632,26 @@ ruleTester.run('no-unused-styles', rule, {
       `.trim(),
       errors: [{
         message: 'Style `foo` is unused',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+          bar: {},
+        }))(Foo);
+      `.trim(),
+      errors: [{
+        message: 'Style `bar` is unused',
         type: 'Property',
       }],
     },

--- a/tests/lib/rules/only-spread-css.js
+++ b/tests/lib/rules/only-spread-css.js
@@ -54,54 +54,6 @@ ruleTester.run('only-spread-css', rule, {
         <div {...css(foo)} {...bar()} />
       `.trim(),
     },
-
-    {
-      parserOptions,
-      code: `
-        import { css } from 'somethingElse';
-        <div {...css(foo)} className="foo" />
-      `.trim(),
-    },
-
-    {
-      parserOptions,
-      code: `
-        import { css } from 'somethingElse';
-        <div {...css(foo)} style={{ color: 'red' }} />
-      `.trim(),
-    },
-
-    {
-      parserOptions,
-      code: `
-        const { css } = require('somethingElse');
-        <div {...css(foo)} className="foo" />
-      `.trim(),
-    },
-
-    {
-      parserOptions,
-      code: `
-        const { css } = require('somethingElse');
-        <div {...css(foo)} style={{ color: 'red' }} />
-      `.trim(),
-    },
-
-    {
-      parserOptions,
-      code: `
-        require(foo);
-        <div {...css(foo)} style={{ color: 'red' }} />
-      `.trim(),
-    },
-
-    {
-      parserOptions,
-      code: `
-        require();
-        <div {...css(foo)} style={{ color: 'red' }} />
-      `.trim(),
-    },
   ],
 
   invalid: [
@@ -222,18 +174,6 @@ ruleTester.run('only-spread-css', rule, {
     {
       parserOptions,
       code: `
-        import { css as bar } from 'withStyles';
-        <div {...bar(foo)} className="foo" />
-      `.trim(),
-      errors: [{
-        message: 'Do not use `className` with `{...bar()}`.',
-        type: 'JSXAttribute',
-      }],
-    },
-
-    {
-      parserOptions,
-      code: `
         const { css } = require('withStyles');
         <div {...css(foo)} className="foo" />
       `.trim(),
@@ -251,18 +191,6 @@ ruleTester.run('only-spread-css', rule, {
       `.trim(),
       errors: [{
         message: 'Do not use `style` with `{...css()}`.',
-        type: 'JSXAttribute',
-      }],
-    },
-
-    {
-      parserOptions,
-      code: `
-        const { css: bar } = require('withStyles');
-        <div {...bar(foo)} className="foo" />
-      `.trim(),
-      errors: [{
-        message: 'Do not use `className` with `{...bar()}`.',
         type: 'JSXAttribute',
       }],
     },


### PR DESCRIPTION
As of react-with-styles@3.0.0, we expect users to be consuming the `css` method as a prop rather than as a global. As such, we need to update `no-unused-styles` to flag for this situation.

I consider this change to be a patch change. 

In a follow up (breaking) PR, I will be do a few more things:
1) turn on no-unused-styles as recommended
2) add a recommendation to flag the global import of css and cssNoRTL
3) Remove the now unused utils `findImportCSSFromWithStylesImportDeclaration` and `findRequireCSSFromWithStylesCallExpression`

to: @lencioni @ljharb @airbnb/webinfra 