### PR TITLE
Update for eslint v5

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
   },
   "rules": {
     "strict": 0,
+    "prefer-destructuring": 0,
     "comma-dangle": [2, {
       "arrays": "always-multiline",
       "objects": "always-multiline",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: false
 node_js:
+  - '10'
+  - '8'
   - '6'
-  - '5'
-  - '4'

--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -6,10 +6,14 @@ function getBasicIdentifier(node) {
   if (node.type === 'Identifier') {
     // styles.foo
     return node.name;
-  } else if (node.type === 'Literal') {
+  }
+
+  if (node.type === 'Literal') {
     // styles['foo']
     return node.value;
-  } else if (node.type === 'TemplateLiteral') {
+  }
+
+  if (node.type === 'TemplateLiteral') {
     // styles[`foo`]
     if (node.expressions.length) {
       // styles[`foo${bar}`]
@@ -51,8 +55,8 @@ module.exports = {
             } else if (body.type === 'BlockStatement') {
               body.body.forEach((bodyNode) => {
                 if (
-                  bodyNode.type === 'ReturnStatement' &&
-                  bodyNode.argument.type === 'ObjectExpression'
+                  bodyNode.type === 'ReturnStatement'
+                  && bodyNode.argument.type === 'ObjectExpression'
                 ) {
                   stylesObj = bodyNode.argument;
                 }
@@ -68,7 +72,7 @@ module.exports = {
                   return;
                 }
 
-                if (property.type === 'ExperimentalSpreadProperty') {
+                if (property.type === 'ExperimentalSpreadProperty' || property.type === 'SpreadElement') {
                   // Skip over object spread for now.
                   // e.g. `{ ...foo }`
                   // TODO handle this better?

--- a/package.json
+++ b/package.json
@@ -41,15 +41,15 @@
   },
   "homepage": "https://github.com/airbnb/eslint-plugin-react-with-styles#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "eslint": "^4.3.0",
-    "eslint-config-airbnb-base": "^11.3.0",
+    "eslint": "^5.3.0",
+    "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.7.0",
     "in-publish": "^2.0.0",
-    "mocha": "^3.2.0",
+    "mocha": "^5.2.0",
     "safe-publish-latest": "^1.1.1"
   },
   "dependencies": {

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -5,9 +5,9 @@
 
 'use strict';
 
-const rule = require('../../../lib/rules/no-unused-styles');
-
 const RuleTester = require('eslint').RuleTester;
+
+const rule = require('../../../lib/rules/no-unused-styles');
 
 const parserOptions = {
   ecmaVersion: 6,

--- a/tests/lib/rules/only-spread-css.js
+++ b/tests/lib/rules/only-spread-css.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-const rule = require('../../../lib/rules/only-spread-css');
-
 const RuleTester = require('eslint').RuleTester;
+
+const rule = require('../../../lib/rules/only-spread-css');
 
 const parserOptions = {
   ecmaVersion: 6,


### PR DESCRIPTION
It seems that spreads in JSX are now called SpreadElement instead of
ExperimentalSpreadProperty.

@majapw @ljharb 