### PR TITLE
Create only-extend-defined rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,13 @@
 
 const onlySpreadCSS = require('./rules/only-spread-css');
 const noUnusedStyles = require('./rules/no-unused-styles');
+const onlyExtendDefined = require('./rules/only-extend-defined');
 
 module.exports = {
   rules: {
     'only-spread-css': onlySpreadCSS,
     'no-unused-styles': noUnusedStyles,
+    'only-extend-defined': onlyExtendDefined,
   },
 
   configs: {
@@ -14,6 +16,7 @@ module.exports = {
       rules: {
         'react-with-styles/only-spread-css': 'error',
         'react-with-styles/no-unused-styles': 'error',
+        'react-with-styles/only-extend-defined': 'error',
         'no-restricted-imports': ['error', {
           paths: [{
             name: 'react-with-styles',

--- a/lib/rules/only-extend-defined.js
+++ b/lib/rules/only-extend-defined.js
@@ -1,0 +1,121 @@
+'use strict';
+
+// Traverse the style object and gather all possible paths
+const gatherDefinedStylePaths = (acc, styleObject, currentPath = '') => {
+  styleObject.properties.forEach((property) => {
+    if (property.computed) {
+      // Skip over computed properties for now.
+      // e.g. `{ [foo]: { ... } }`
+      // TODO handle this better?
+      return;
+    }
+
+    if (property.type === 'ExperimentalSpreadProperty' || property.type === 'SpreadElement') {
+      // Skip over object spread for now.
+      // e.g. `{ ...foo }`
+      // TODO handle this better?
+      return;
+    }
+
+    const propertyName = property.key.value || property.key.name;
+    const path = currentPath ? `${currentPath}.${propertyName}` : propertyName;
+
+    // Save the path
+    acc[path] = true;
+
+    // Continue traversing
+    if (property.value.type === 'ObjectExpression') {
+      gatherDefinedStylePaths(acc, property.value, path);
+    }
+  });
+};
+
+// Traverse extendable styles and validate that all possible paths exist in the defined styles
+const checkExtendedStyles = (context, definedStylePaths, extendedStyle, currentPath = '') => {
+  extendedStyle.properties.forEach((property) => {
+    if (property.computed) {
+      // Skip over computed properties for now.
+      // e.g. `{ [foo]: { ... } }`
+      // TODO handle this better?
+      return;
+    }
+
+    if (property.type === 'ExperimentalSpreadProperty' || property.type === 'SpreadElement') {
+      // Skip over object spread for now.
+      // e.g. `{ ...foo }`
+      // TODO handle this better?
+      return;
+    }
+
+    const propertyName = property.key.value || property.key.name;
+    const path = currentPath ? `${currentPath}.${propertyName}` : propertyName;
+
+    // Fire the lint rule if the path is not found
+    if (!definedStylePaths[path]) {
+      context.report(
+        property,
+        `\`${propertyName}\` is not extendable`
+      );
+      return;
+    }
+
+    // Continue traversing
+    if (property.value.type === 'ObjectExpression') {
+      checkExtendedStyles(context, definedStylePaths, property.value, path);
+    }
+  });
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Require that all styles that are extendable are defined on the component.',
+      recommended: true,
+    },
+
+    schema: [],
+  },
+
+  create: function rule(context) {
+    // Paths that exist in the defined styles
+    const definedStyles = {};
+
+    return {
+      CallExpression(node) {
+        if (node.callee.name === 'withStyles') {
+          const styles = node.arguments[0];
+          if (styles && styles.type === 'ArrowFunctionExpression') {
+            const body = styles.body;
+
+            let stylesObj;
+            if (body.type === 'ObjectExpression') {
+              stylesObj = body;
+            } else if (body.type === 'BlockStatement') {
+              body.body.forEach((bodyNode) => {
+                if (
+                  bodyNode.type === 'ReturnStatement'
+                  && bodyNode.argument.type === 'ObjectExpression'
+                ) {
+                  stylesObj = bodyNode.argument;
+                }
+              });
+            }
+
+            if (stylesObj) {
+              gatherDefinedStylePaths(definedStyles, stylesObj);
+            }
+          }
+
+          const options = node.arguments[1];
+          if (options && options.type === 'ObjectExpression') {
+            options.properties.forEach((optionProperty) => {
+              if (optionProperty.key.name === 'extendableStyles' && optionProperty.value.type === 'ObjectExpression') {
+                checkExtendedStyles(context, definedStyles, optionProperty.value);
+              }
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/only-extend-defined.js
+++ b/tests/lib/rules/only-extend-defined.js
@@ -1,0 +1,1259 @@
+/**
+* @fileoverview Require that all styles that are extendable are defined on the component.
+* @author Tae Kim
+*/
+
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+
+const rule = require('../../../lib/rules/only-extend-defined');
+
+const parserOptions = {
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    jsx: true,
+    experimentalObjectRestSpread: true,
+  },
+  sourceType: 'module',
+};
+
+const ruleTester = new RuleTester();
+ruleTester.run('only-extend-defined', rule, {
+
+  valid: [
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+        <div className="foo" />
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+        const foo = props.styles;
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div {...css(styles['foo'])} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div {...css(styles[\`foo\`])} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo(props) {
+          return (
+            <div {...css(props.styles.foo)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo(props) {
+          return (
+            <div {...css(props.styles['foo'])} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo(props) {
+          return (
+            <div {...css(props['styles'].foo)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo(props) {
+          return (
+            <div {...css(props['styles']['foo'])} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo(props) {
+          return (
+            <div {...css(props.styles[\`foo\`])} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo(props) {
+          return (
+            <div {...css(props[\`styles\`].foo)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo(props) {
+          return (
+            <div {...css(props[\`styles\`][\`foo\`])} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this.props.styles.foo)} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this.props.styles['foo'])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this.props['styles']['foo'])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this['props'].styles['foo'])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this['props']['styles']['foo'])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this.props.styles[\`foo\`])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this.props[\`styles\`][\`foo\`])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this[\`props\`].styles[\`foo\`])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            return <div {...css(this[\`props\`][\`styles\`][\`foo\`])} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        class Foo extends React.Component {
+          render() {
+            const { styles } = this.props;
+            return <div {...css(styles.foo)} />;
+          }
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          const something = isActive ? styles.foo : null;
+          return <div {...css(something)} />;
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    { // TODO handle computed properties better?
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div />
+          );
+        }
+
+        export default withStyles(() => ({
+          [foo]: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    { // TODO handle object spread better?
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div />
+          );
+        }
+
+        export default withStyles(() => ({
+          ...foo,
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(() => {
+          return {
+            foo: {},
+          }
+        })(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div {...css(styles.foo, styles.bar)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+          bar: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        import { css } from 'withStyles';
+
+        function Foo({ styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)} />
+            </div>
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+          bar: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(() => ({
+          foo: {},
+        }))(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+          }),
+          {},
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {},
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+              color: 'blue',
+              fontSize: 12,
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+                color: () => true,
+                fontSize: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)}>FOO</div>
+            </div>
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+            bar: {
+              color: 'purple',
+            }
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+              },
+              bar: {
+                color: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)}>BAR</div>
+              <div {...css(styles.zar)}>ZAR</div>
+            </div>
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+              fontSize: 12,
+              padding: 30,
+            },
+            bar: {
+              color: 'purple',
+              margin: 15,
+            },
+            zar: {
+              border: '1px solid black',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+                fontSize: () => true,
+                padding: () => true,
+              },
+              bar: {
+                color: () => true,
+                margin: () => true,
+              },
+              zar: {
+                border: () => true,
+              }
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)}>BAR</div>
+              <div {...css(styles.zar)}>ZAR</div>
+            </div>
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+              fontSize: 12,
+              padding: 30,
+            },
+            bar: {
+              color: 'purple',
+              margin: 15,
+            },
+            zar: {
+              border: '1px solid black',
+            },
+          }),
+          {
+            extendableStyles: {
+              bar: {
+                color: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        const className = 'foo';
+
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            [className]: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {
+              [className]: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        const className = 'foo';
+
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            [className]: {
+              background: 'red',
+              color: 'purple',
+              fontSize: 12,
+            },
+          }),
+          {
+            extendableStyles: {
+              [className]: {
+                background: () => true,
+                color: () => true,
+                fontSize: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        const styles = {
+          background: 'red',
+          color: 'purple',
+          fontSize: 12,
+        };
+
+        const extendableStyles = {
+          background: () => true,
+          color: () => true,
+          fontSize: () => true,
+        };
+
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              ...styles,
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                ...extendableStyles
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+
+    {
+      parserOptions,
+      code: `
+        const extendableStyles = {
+          background: () => true,
+          color: () => true,
+          fontSize: () => true,
+        };
+
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+              color: 'purple',
+              fontSize: 12,
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                ...extendableStyles
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+    },
+  ],
+
+  invalid: [
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({}),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`foo` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {},
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`background` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {
+              bar: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`bar` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                color: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`color` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+                fontSize: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`fontSize` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+                color: () => true,
+                fontSize: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [
+        {
+          message: '`color` is not extendable',
+          type: 'Property',
+        },
+        {
+          message: '`fontSize` is not extendable',
+          type: 'Property',
+        },
+      ],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)} />
+            </div>
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+            bar: {
+              color: 'purple',
+            },
+          }),
+          {
+            extendableStyles: {
+              test: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`test` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)} />
+            </div>
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+            bar: {
+              color: 'purple',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                color: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`color` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)} />
+            </div>
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+            bar: {
+              color: 'purple',
+            },
+          }),
+          {
+            extendableStyles: {
+              bar: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`background` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)}>
+              <div {...css(styles.bar)} />
+            </div>
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              background: 'red',
+            },
+            bar: {
+              color: 'purple',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                fontSize: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`fontSize` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        const className = 'foo';
+
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            [className]: {
+              background: 'red',
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [{
+        message: '`foo` is not extendable',
+        type: 'Property',
+      }],
+    },
+
+    {
+      parserOptions,
+      code: `
+        const styles = {
+          background: 'red',
+          color: 'purple',
+          fontSize: 12,
+        };
+
+        function Foo({ css, styles }) {
+          return (
+            <div {...css(styles.foo)} />
+          );
+        }
+
+        export default withStyles(
+          () => ({
+            foo: {
+              ...styles,
+            },
+          }),
+          {
+            extendableStyles: {
+              foo: {
+                background: () => true,
+                color: () => true,
+                fontSize: () => true,
+              },
+            },
+          },
+        )(Foo);
+      `.trim(),
+      errors: [
+        {
+          message: '`background` is not extendable',
+          type: 'Property',
+        },
+        {
+          message: '`color` is not extendable',
+          type: 'Property',
+        },
+        {
+          message: '`fontSize` is not extendable',
+          type: 'Property',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
"only-extend-defined" ESLint Rule
Ensures that any extendable styles are defined in the component's style definition. This PR was created based on feedback on the [extending styles PR](https://github.com/airbnb/react-with-styles/pull/210).

`Failing Example`
```
export default withStyles(
  () => ({
    container: {
      background: 'red',
    },
  }),
  {
    extendableStyles: {
      container: {
        color: () => true, // would fail here
      },
      foo: { // would also fail here
        background: () => true,
      },
    },
  },
)(Foo);
```